### PR TITLE
chore(db): use postgres instead of mssql

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -7,12 +7,11 @@ DEBUG=True
 SECRET_KEY=secret
 
 # Database configuration
-DB_ENGINE=mssql
 DB_NAME=your_db_name
 DB_USER=your_db_user
 DB_PASSWORD=your_db_password
 DB_HOST=localhost
-DB_PORT=1433
+DB_PORT=5432
 
 # HOST
 ALLOWED_HOSTS=localhost

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,11 +3,10 @@ Django==5.0.14
 django-environ==0.12.0
 djangorestframework==3.16.0
 gunicorn==23.0.0
-mssql-django==1.5
 packaging==25.0
-pyodbc==5.2.0
 pytz==2025.2
 sqlparse==0.5.3
 tzdata==2025.2
 whitenoise==6.9.0
 django-cors-headers
+psycopg2-binary

--- a/backend/server/settings.py
+++ b/backend/server/settings.py
@@ -94,15 +94,12 @@ WSGI_APPLICATION = "server.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "mssql",
+        "ENGINE": "django.db.backends.postgresql",
         "NAME": env("DB_NAME", default="DB_NAME"),
         "USER": env("DB_USER", default="DB_USER"),
         "PASSWORD": env("DB_PASSWORD", default="DB_PASSWORD"),
         "HOST": env("DB_HOST", default="DB_HOST"),
         "PORT": env("DB_PORT", default="DB_PORT"),
-        "OPTIONS": {
-            "driver": "ODBC Driver 18 for SQL Server",
-        },
     },
 }
 


### PR DESCRIPTION
Replaced Microsoft SQL Server with PostgreSQL as the backend database for the Django application.

### Changes

- Switched database engine from `mssql-django` to `django.db.backends.postgresql`
- Installed `psycopg2-binary` as the PostgreSQL driver
- Removed SQL Server-related packages: `mssql-django`, `pyodbc`
- Updated `.env` and `settings.py` to support PostgreSQL configuration

### Why
- SQL Server had long cold start times and increased cloud costs (vCore model)
- PostgreSQL offers better developer experience and faster cold starts (Hetzner)